### PR TITLE
Remove switch statement for ProcessJobConsumer

### DIFF
--- a/src/SampleBatch.Api/Controllers/BatchJobsController.cs
+++ b/src/SampleBatch.Api/Controllers/BatchJobsController.cs
@@ -88,7 +88,7 @@ namespace SampleBatch.Api.Controllers
             {
                 BatchId = id,
                 InVar.Timestamp,
-                Action = BatchAction.CancelOrders,
+                Action = BatchActionEnum.CancelOrders,
                 OrderIds = orderIds.ToArray(),
                 ActiveThreshold = activeThreshold,
                 DelayInSeconds = delayInSeconds

--- a/src/SampleBatch.Components/Consumers/ProcessBatchJobConsumer.cs
+++ b/src/SampleBatch.Components/Consumers/ProcessBatchJobConsumer.cs
@@ -1,9 +1,7 @@
 ﻿namespace SampleBatch.Components.Consumers
 {
-    using System;
     using System.Threading.Tasks;
     using Contracts;
-    using Contracts.Enums;
     using MassTransit;
     using MassTransit.Courier;
     using MassTransit.Courier.Contracts;
@@ -24,63 +22,20 @@
         {
             using (_log.BeginScope("ProcessBatchJob {BatchJobId}, {OrderId}", context.Message.BatchJobId, context.Message.OrderId))
             {
-                var builder = new RoutingSlipBuilder(NewId.NextGuid());
-
-                switch (context.Message.Action)
+                var routingSlip = await context.Message.Action.SetupRoutingSlip(context, async builder =>
                 {
-                    case BatchAction.CancelOrders:
-                        builder.AddActivity(
-                            "CancelOrder",
-                            new Uri("queue:cancel-order_execute"),
-                            new
-                            {
-                                context.Message.OrderId,
-                                Reason = "Product discontinued"
-                            });
+                    await builder.AddSubscription(
+                        context.SourceAddress,
+                        RoutingSlipEvents.Completed,
+                        x => x.Send<BatchJobCompleted>(new
+                        {
+                            context.Message.BatchJobId,
+                            context.Message.BatchId,
+                            InVar.Timestamp
+                        }));
+                });
 
-                        await builder.AddSubscription(
-                            context.SourceAddress,
-                            RoutingSlipEvents.ActivityFaulted,
-                            RoutingSlipEventContents.None,
-                            "CancelOrder",
-                            x => x.Send<BatchJobFailed>(new
-                            {
-                                context.Message.BatchJobId,
-                                context.Message.BatchId,
-                                context.Message.OrderId
-                            }));
-                        break;
-
-                    case BatchAction.SuspendOrders:
-                        builder.AddActivity(
-                            "SuspendOrder",
-                            new Uri("queue:suspend-order_execute"),
-                            new {context.Message.OrderId});
-
-                        await builder.AddSubscription(
-                            context.SourceAddress,
-                            RoutingSlipEvents.ActivityFaulted,
-                            RoutingSlipEventContents.None,
-                            "SuspendOrder",
-                            x => x.Send<BatchJobFailed>(new
-                            {
-                                context.Message.BatchJobId,
-                                context.Message.BatchId,
-                                context.Message.OrderId
-                            }));
-                        break;
-                }
-
-                await builder.AddSubscription(
-                    context.SourceAddress,
-                    RoutingSlipEvents.Completed,
-                    x => x.Send<BatchJobCompleted>(new
-                    {
-                        context.Message.BatchJobId,
-                        context.Message.BatchId
-                    }));
-
-                await context.Execute(builder.Build());
+                await context.Execute(routingSlip);
             }
         }
     }

--- a/src/SampleBatch.Components/SampleBatchDbContext.cs
+++ b/src/SampleBatch.Components/SampleBatchDbContext.cs
@@ -1,8 +1,6 @@
 ﻿using Microsoft.EntityFrameworkCore;
 using SampleBatch.Components.StateMachines;
-using System;
-using System.Collections.Generic;
-using System.Text;
+
 
 namespace SampleBatch.Components
 {

--- a/src/SampleBatch.Components/StateMachines/BatchState.cs
+++ b/src/SampleBatch.Components/StateMachines/BatchState.cs
@@ -19,12 +19,12 @@
 
         public DateTime? UpdateTimestamp { get; set; }
 
-        public BatchAction? Action { get; set; }
+        public BatchActionEnum Action { get; set; }
 
-        /// <summary>
-        /// The maximum amount of active Jobs allowed to be processing. Typically an amount larger than your Job Consumer can handle concurrently, to allow for some additional prefetch while the Batch Saga dispatches more
-        /// </summary>
-        public int? ActiveThreshold { get; set; } = 20;
+    /// <summary>
+    /// The maximum amount of active Jobs allowed to be processing. Typically an amount larger than your Job Consumer can handle concurrently, to allow for some additional prefetch while the Batch Saga dispatches more
+    /// </summary>
+    public int? ActiveThreshold { get; set; } = 20;
 
         public int? Total { get; set; }
 

--- a/src/SampleBatch.Components/StateMachines/BatchStateEntityConfiguration.cs
+++ b/src/SampleBatch.Components/StateMachines/BatchStateEntityConfiguration.cs
@@ -2,11 +2,11 @@
 {
     using System;
     using System.Collections.Generic;
+    using System.Linq;
     using Common;
     using Contracts.Enums;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.Metadata.Builders;
-    using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 
     class BatchStateEntityConfiguration :
@@ -22,8 +22,9 @@
 
             builder.Property(c => c.CurrentState).IsRequired();
 
-            builder.Property(c => c.Action)
-                .HasConversion(new EnumToStringConverter<BatchAction>());
+            builder.Property(p => p.Action)
+                .HasConversion(v => v.Value, i => BatchActionEnum.List().FirstOrDefault(e => e.Value == i));
+
 
             builder.Property(c => c.UnprocessedOrderIds)
                 .HasConversion(new JsonValueConverter<Stack<Guid>>())

--- a/src/SampleBatch.Components/StateMachines/JobState.cs
+++ b/src/SampleBatch.Components/StateMachines/JobState.cs
@@ -20,7 +20,7 @@
 
         public DateTime? UpdateTimestamp { get; set; }
 
-        public BatchAction Action { get; set; }
+        public BatchActionEnum Action { get; set; }
 
         public string ExceptionMessage { get; set; }
 

--- a/src/SampleBatch.Components/StateMachines/JobStateEntityConfiguration.cs
+++ b/src/SampleBatch.Components/StateMachines/JobStateEntityConfiguration.cs
@@ -1,9 +1,9 @@
 ﻿namespace SampleBatch.Components.StateMachines
 {
+    using System.Linq;
     using Contracts.Enums;
     using Microsoft.EntityFrameworkCore;
     using Microsoft.EntityFrameworkCore.Metadata.Builders;
-    using Microsoft.EntityFrameworkCore.Storage.ValueConversion;
 
 
     class JobStateEntityConfiguration :
@@ -19,8 +19,8 @@
 
             builder.Property(c => c.CurrentState).IsRequired();
 
-            builder.Property(c => c.Action)
-                .HasConversion(new EnumToStringConverter<BatchAction>());
+            builder.Property(p => p.Action)
+                .HasConversion(v => v.Value, i => BatchActionEnum.List().FirstOrDefault(e => e.Value == i));
         }
     }
 }

--- a/src/SampleBatch.Contracts/BatchJobReceived.cs
+++ b/src/SampleBatch.Contracts/BatchJobReceived.cs
@@ -10,6 +10,6 @@
         Guid BatchId { get; }
         Guid OrderId { get; }
         DateTime Timestamp { get; }
-        BatchAction Action { get; }
+        BatchActionEnum Action { get; }
     }
 }

--- a/src/SampleBatch.Contracts/BatchReceived.cs
+++ b/src/SampleBatch.Contracts/BatchReceived.cs
@@ -8,7 +8,7 @@
     {
         Guid BatchId { get; }
         DateTime Timestamp { get; }
-        BatchAction Action { get; }
+        BatchActionEnum Action { get; }
         Guid[] OrderIds { get; }
         int ActiveThreshold { get; }
 

--- a/src/SampleBatch.Contracts/Enums/BatchAction.cs
+++ b/src/SampleBatch.Contracts/Enums/BatchAction.cs
@@ -1,8 +1,0 @@
-﻿namespace SampleBatch.Contracts.Enums
-{
-    public enum BatchAction
-    {
-        CancelOrders = 1,
-        SuspendOrders = 2
-    }
-}

--- a/src/SampleBatch.Contracts/Enums/BatchActionEnum.cs
+++ b/src/SampleBatch.Contracts/Enums/BatchActionEnum.cs
@@ -1,0 +1,50 @@
+﻿namespace SampleBatch.Contracts.Enums
+{
+    using System;
+    using System.Collections.Generic;
+    using System.Threading.Tasks;
+    using Converter;
+    using Internal;
+    using MassTransit;
+    using MassTransit.Courier;
+    using MassTransit.Courier.Contracts;
+    using Newtonsoft.Json;
+
+
+    [JsonConverter(typeof(BatchActionEnumConverter))]
+    public abstract class BatchActionEnum
+    {
+        public static readonly BatchActionEnum CancelOrders = new CancelOrdersEnum();
+        public static readonly BatchActionEnum SuspendOrders = new SuspendOrdersEnum();
+
+        public int Value { get; private set; }
+        public string Name { get; private set; }
+
+        public static IEnumerable<BatchActionEnum> List()
+        {
+            yield return CancelOrders;
+            yield return SuspendOrders;
+        }
+        
+        protected BatchActionEnum(int value, string name)
+        {
+            Value = value;
+            Name = name;
+        }
+
+        public async Task<RoutingSlip> SetupRoutingSlip(ConsumeContext<ProcessBatchJob> context, Func<RoutingSlipBuilder, Task> commonAction)
+        {
+            var builder = new RoutingSlipBuilder(NewId.NextGuid());
+
+            await SetupRoutingSlip(builder, context);
+
+            await commonAction?.Invoke(builder);
+
+            return builder.Build();
+
+        }
+
+        protected abstract Task SetupRoutingSlip(RoutingSlipBuilder builder, ConsumeContext<ProcessBatchJob> context);
+
+    }
+}

--- a/src/SampleBatch.Contracts/Enums/Converter/BatchActionEnumConverter.cs
+++ b/src/SampleBatch.Contracts/Enums/Converter/BatchActionEnumConverter.cs
@@ -1,0 +1,53 @@
+﻿namespace SampleBatch.Contracts.Enums.Converter
+{
+    using System;
+    using Internal;
+    using Newtonsoft.Json;
+    using Newtonsoft.Json.Linq;
+    using Newtonsoft.Json.Serialization;
+
+
+    public class BaseSpecifiedConcreteClassConverter : DefaultContractResolver
+    {
+        protected override JsonConverter ResolveContractConverter(Type objectType)
+        {
+            if (typeof(BatchActionEnum).IsAssignableFrom(objectType) && !objectType.IsAbstract)
+                return null; // pretend TableSortRuleConvert is not specified (thus avoiding a stack overflow)
+            return base.ResolveContractConverter(objectType);
+        }
+    }
+
+    public class BatchActionEnumConverter : JsonConverter
+    {
+        static readonly JsonSerializerSettings SpecifiedSubclassConversion = new JsonSerializerSettings() { ContractResolver = new BaseSpecifiedConcreteClassConverter() };
+
+        public override bool CanConvert(Type objectType)
+        {
+            return (objectType == typeof(BatchActionEnum));
+        }
+
+        public override object ReadJson(JsonReader reader, Type objectType, object existingValue, JsonSerializer serializer)
+        {
+            JObject jo = JObject.Load(reader);
+            switch (jo["value"].Value<int>())
+            {
+                case 1:
+                    return JsonConvert.DeserializeObject<CancelOrdersEnum>(jo.ToString(), SpecifiedSubclassConversion);
+                case 2:
+                    return JsonConvert.DeserializeObject<SuspendOrdersEnum>(jo.ToString(), SpecifiedSubclassConversion);
+                default:
+                    throw new Exception();
+            }
+            throw new NotImplementedException();
+        }
+
+        public override bool CanWrite {
+            get { return false; }
+        }
+
+        public override void WriteJson(JsonWriter writer, object value, JsonSerializer serializer)
+        {
+            throw new NotImplementedException(); // won't be called because CanWrite returns false
+        }
+    }
+}

--- a/src/SampleBatch.Contracts/Enums/Internal/CancelOrdersEnum.cs
+++ b/src/SampleBatch.Contracts/Enums/Internal/CancelOrdersEnum.cs
@@ -1,0 +1,41 @@
+﻿namespace SampleBatch.Contracts.Enums.Internal
+{
+    using System;
+    using System.Threading.Tasks;
+    using MassTransit;
+    using MassTransit.Courier;
+    using MassTransit.Courier.Contracts;
+
+
+    class CancelOrdersEnum : BatchActionEnum
+    {
+        public CancelOrdersEnum()
+            : base(1, "Cancel Orders")
+        {
+        }
+
+        protected override async Task SetupRoutingSlip( RoutingSlipBuilder builder, ConsumeContext<ProcessBatchJob> context)
+        {
+            builder.AddActivity(
+                "CancelOrder",
+                new Uri("queue:cancel-order_execute"),
+                new
+                {
+                    context.Message.OrderId,
+                    Reason = "Product discontinued"
+                });
+
+            await builder.AddSubscription(
+                context.SourceAddress,
+                RoutingSlipEvents.ActivityFaulted,
+                RoutingSlipEventContents.None,
+                "CancelOrder",
+                x => x.Send<BatchJobFailed>(new
+                {
+                    context.Message.BatchJobId,
+                    context.Message.BatchId,
+                    context.Message.OrderId
+                }));
+        }
+    }
+}

--- a/src/SampleBatch.Contracts/Enums/Internal/SuspendOrdersEnum.cs
+++ b/src/SampleBatch.Contracts/Enums/Internal/SuspendOrdersEnum.cs
@@ -1,0 +1,37 @@
+﻿namespace SampleBatch.Contracts.Enums.Internal
+{
+    using System;
+    using System.Threading.Tasks;
+    using MassTransit;
+    using MassTransit.Courier;
+    using MassTransit.Courier.Contracts;
+
+
+    class SuspendOrdersEnum : BatchActionEnum
+    {
+        public SuspendOrdersEnum()
+            : base(2, "Suspend Orders")
+        {
+        }
+
+        protected override async Task SetupRoutingSlip(RoutingSlipBuilder builder, ConsumeContext<ProcessBatchJob> context)
+        {
+            builder.AddActivity(
+                "SuspendOrder",
+                new Uri("queue:suspend-order_execute"),
+                new { context.Message.OrderId });
+
+            await builder.AddSubscription(
+                context.SourceAddress,
+                RoutingSlipEvents.ActivityFaulted,
+                RoutingSlipEventContents.None,
+                "SuspendOrder",
+                x => x.Send<BatchJobFailed>(new
+                {
+                    context.Message.BatchJobId,
+                    context.Message.BatchId,
+                    context.Message.OrderId
+                }));
+        }
+    }
+}

--- a/src/SampleBatch.Contracts/ProcessBatchJob.cs
+++ b/src/SampleBatch.Contracts/ProcessBatchJob.cs
@@ -10,6 +10,6 @@
         Guid BatchId { get; }
         DateTime Timestamp { get; }
         Guid OrderId { get; }
-        BatchAction Action { get; }
+        BatchActionEnum Action { get; }
     }
 }

--- a/src/SampleBatch.Contracts/SubmitBatch.cs
+++ b/src/SampleBatch.Contracts/SubmitBatch.cs
@@ -10,7 +10,7 @@
 
         DateTime Timestamp { get; }
 
-        BatchAction Action { get; }
+        BatchActionEnum Action { get; }
 
         Guid[] OrderIds { get; }
 

--- a/src/SampleBatch.Tests/Integration/BatchStateMachineTests.cs
+++ b/src/SampleBatch.Tests/Integration/BatchStateMachineTests.cs
@@ -81,7 +81,7 @@ namespace SampleBatch.Tests.Integration
                 {
                     BatchId = NewId.NextGuid(),
                     Timestamp = DateTime.UtcNow,
-                    BatchAction = BatchAction.CancelOrders,
+                    BatchAction = BatchActionEnum.CancelOrders,
                     ActiveThreshold = 5,
                     OrderIds = new Guid[] { Guid.NewGuid(), Guid.NewGuid() }
                 });

--- a/src/SampleBatch.Tests/Unit/BatchStateMachineTests.cs
+++ b/src/SampleBatch.Tests/Unit/BatchStateMachineTests.cs
@@ -59,7 +59,7 @@ namespace SampleBatch.Tests.Unit
                 {
                     BatchId = NewId.NextGuid(),
                     Timestamp = DateTime.UtcNow,
-                    BatchAction = BatchAction.CancelOrders,
+                    BatchAction = BatchActionEnum.CancelOrders,
                     ActiveThreshold = 5,
                     OrderIds = new Guid[] { Guid.NewGuid(), Guid.NewGuid() }
                 });
@@ -87,7 +87,7 @@ namespace SampleBatch.Tests.Unit
                 {
                     BatchId = NewId.NextGuid(),
                     Timestamp = DateTime.UtcNow,
-                    BatchAction = BatchAction.CancelOrders,
+                    BatchAction = BatchActionEnum.CancelOrders,
                     ActiveThreshold = 5,
                     OrderIds = new Guid[] { Guid.NewGuid(), Guid.NewGuid() },
                     DelayInSeconds = 60


### PR DESCRIPTION
Dear @phatboyg 

I was reading this sample and saw the following:

> Not too sure how I feel about the enum indicating what batch action to take, and then the switch statement in the ProcessJobConsumer where it conditionally creates the routing slip activity. Is there a more elegant way? I'll need to think about that.

Based on what I read [here](https://docs.microsoft.com/en-us/dotnet/architecture/microservices/microservice-ddd-cqrs-patterns/enumeration-classes-over-enum-types) and [here](https://lostechies.com/jimmybogard/2008/08/12/enumeration-classes/). I used the [SmartEnum](https://www.nuget.org/packages/Ardalis.SmartEnum/) library to tackle this problem. 

I am not sure whether I changed it in an elegant way or not, so please let me know your opinion. 

Thanks.