### PR TITLE
Implemented factories for the routing slip.

### DIFF
--- a/src/SampleBatch.Components/Activities/CancelOrdersRoutingSlipFactory.cs
+++ b/src/SampleBatch.Components/Activities/CancelOrdersRoutingSlipFactory.cs
@@ -1,0 +1,53 @@
+namespace SampleBatch.Components.Activities;
+
+using System;
+using System.Threading.Tasks;
+using Contracts;
+using Contracts.Enums;
+using MassTransit;
+using MassTransit.Courier.Contracts;
+
+public sealed class CancelOrdersRoutingSlipFactory : IRoutingSlipFactory
+{
+    public bool CanCreateSlipFrom(ConsumeContext<ProcessBatchJob> context)
+    {
+        return context.Message.Action == BatchAction.CancelOrders;
+    }
+
+    public async Task<RoutingSlip> CreateSlip(ConsumeContext<ProcessBatchJob> context)
+    {
+        var builder = new RoutingSlipBuilder(NewId.NextGuid());
+
+        builder.AddActivity(
+            "CancelOrder",
+            new Uri("queue:cancel-order_execute"),
+            new
+            {
+                context.Message.OrderId,
+                Reason = "Product discontinued"
+            });
+
+        await builder.AddSubscription(
+            context.SourceAddress,
+            RoutingSlipEvents.ActivityFaulted,
+            RoutingSlipEventContents.None,
+            "CancelOrder",
+            x => x.Send<BatchJobFailed>(new
+            {
+                context.Message.BatchJobId,
+                context.Message.BatchId,
+                context.Message.OrderId
+            }));
+
+        await builder.AddSubscription(
+            context.SourceAddress,
+            RoutingSlipEvents.Completed,
+            x => x.Send<BatchJobCompleted>(new
+            {
+                context.Message.BatchJobId,
+                context.Message.BatchId
+            }));
+
+        return builder.Build();
+    }
+}

--- a/src/SampleBatch.Components/Activities/IRoutingSlipFactory.cs
+++ b/src/SampleBatch.Components/Activities/IRoutingSlipFactory.cs
@@ -1,0 +1,13 @@
+namespace SampleBatch.Components.Activities
+{
+    using System.Threading.Tasks;
+    using Contracts;
+    using MassTransit;
+    using MassTransit.Courier.Contracts;
+
+    public interface IRoutingSlipFactory
+    {
+        bool CanCreateSlipFrom(ConsumeContext<ProcessBatchJob> context);
+        Task<RoutingSlip> CreateSlip(ConsumeContext<ProcessBatchJob> context);
+    }
+}

--- a/src/SampleBatch.Components/Activities/SuspendOrdersRoutingSlipFactory.cs
+++ b/src/SampleBatch.Components/Activities/SuspendOrdersRoutingSlipFactory.cs
@@ -1,0 +1,49 @@
+namespace SampleBatch.Components.Activities;
+
+using System;
+using System.Threading.Tasks;
+using Contracts;
+using Contracts.Enums;
+using MassTransit;
+using MassTransit.Courier.Contracts;
+
+public sealed class SuspendOrdersRoutingSlipFactory : IRoutingSlipFactory
+{
+    public bool CanCreateSlipFrom(ConsumeContext<ProcessBatchJob> context)
+    {
+        return context.Message.Action == BatchAction.SuspendOrders;
+    }
+
+    public async Task<RoutingSlip> CreateSlip(ConsumeContext<ProcessBatchJob> context)
+    {
+        var builder = new RoutingSlipBuilder(NewId.NextGuid());
+
+        builder.AddActivity(
+            "SuspendOrder",
+            new Uri("queue:suspend-order_execute"),
+            new { context.Message.OrderId });
+
+        await builder.AddSubscription(
+            context.SourceAddress,
+            RoutingSlipEvents.ActivityFaulted,
+            RoutingSlipEventContents.None,
+            "SuspendOrder",
+            x => x.Send<BatchJobFailed>(new
+            {
+                context.Message.BatchJobId,
+                context.Message.BatchId,
+                context.Message.OrderId
+            }));
+
+        await builder.AddSubscription(
+            context.SourceAddress,
+            RoutingSlipEvents.Completed,
+            x => x.Send<BatchJobCompleted>(new
+            {
+                context.Message.BatchJobId,
+                context.Message.BatchId
+            }));
+
+        return builder.Build();
+    }
+}

--- a/src/SampleBatch.Service/Program.cs
+++ b/src/SampleBatch.Service/Program.cs
@@ -39,6 +39,9 @@
                     var appConfig = hostContext.Configuration.GetSection(nameof(AppConfig)).Get<AppConfig>();
                     services.Configure<AppConfig>(options => hostContext.Configuration.GetSection("AppConfig").Bind(options));
 
+                    services.AddScoped<IRoutingSlipFactory, CancelOrdersRoutingSlipFactory>();
+                    services.AddScoped<IRoutingSlipFactory, SuspendOrdersRoutingSlipFactory>();
+
                     services.AddMassTransit(cfg =>
                     {
                         cfg.SetKebabCaseEndpointNameFormatter();


### PR DESCRIPTION
Instead of relying on the switch statement, the responsibility of buidling the slip is moved to a factory. Each factory knows how to build a concrete routing slip (S from SOLID). Factories are injected as a collection into the handler, and the handler tries to delegate creation of a routing slip to every factory. If there is a new batch action added in the future, then it will be just a matter of implementing a new factory class and injecting it into the handler (O from SOLID).